### PR TITLE
Add topic for dialog action status

### DIFF
--- a/bt_nodes/hri/include/hri/dialog/DialogConfirmation.hpp
+++ b/bt_nodes/hri/include/hri/dialog/DialogConfirmation.hpp
@@ -22,26 +22,25 @@
 #include "behaviortree_cpp_v3/bt_factory.h"
 #include "hri/dialog/BTActionNode.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/int8.hpp"
 #include "whisper_msgs/action/stt.hpp"
 
-namespace dialog
-{
+namespace dialog {
 
 class DialogConfirmation
-  : public dialog::BtActionNode<whisper_msgs::action::STT>
-{
+    : public dialog::BtActionNode<whisper_msgs::action::STT> {
 public:
-  explicit DialogConfirmation(
-    const std::string & xml_tag_name,
-    const std::string & action_name,
-    const BT::NodeConfiguration & conf);
+  explicit DialogConfirmation(const std::string &xml_tag_name,
+                              const std::string &action_name,
+                              const BT::NodeConfiguration &conf);
 
   void on_tick() override;
   BT::NodeStatus on_success() override;
 
-  static BT::PortsList providedPorts() {return BT::PortsList({});}
+  static BT::PortsList providedPorts() { return BT::PortsList({}); }
 
 private:
+  rclcpp::Publisher<std_msgs::msg::Int8>::SharedPtr publisher_start_;
 };
 
 } // namespace dialog

--- a/bt_nodes/hri/include/hri/dialog/DialogConfirmation.hpp
+++ b/bt_nodes/hri/include/hri/dialog/DialogConfirmation.hpp
@@ -25,19 +25,22 @@
 #include "std_msgs/msg/int8.hpp"
 #include "whisper_msgs/action/stt.hpp"
 
-namespace dialog {
+namespace dialog
+{
 
 class DialogConfirmation
-    : public dialog::BtActionNode<whisper_msgs::action::STT> {
+  : public dialog::BtActionNode<whisper_msgs::action::STT>
+{
 public:
-  explicit DialogConfirmation(const std::string &xml_tag_name,
-                              const std::string &action_name,
-                              const BT::NodeConfiguration &conf);
+  explicit DialogConfirmation(
+    const std::string & xml_tag_name,
+    const std::string & action_name,
+    const BT::NodeConfiguration & conf);
 
   void on_tick() override;
   BT::NodeStatus on_success() override;
 
-  static BT::PortsList providedPorts() { return BT::PortsList({}); }
+  static BT::PortsList providedPorts() {return BT::PortsList({});}
 
 private:
   rclcpp::Publisher<std_msgs::msg::Int8>::SharedPtr publisher_start_;

--- a/bt_nodes/hri/include/hri/dialog/Listen.hpp
+++ b/bt_nodes/hri/include/hri/dialog/Listen.hpp
@@ -26,18 +26,22 @@
 #include "std_msgs/msg/int8.hpp"
 #include "whisper_msgs/action/stt.hpp"
 
-namespace dialog {
+namespace dialog
+{
 
-class Listen : public dialog::BtActionNode<whisper_msgs::action::STT> {
+class Listen : public dialog::BtActionNode<whisper_msgs::action::STT>
+{
 public:
-  explicit Listen(const std::string &xml_tag_name,
-                  const std::string &action_name,
-                  const BT::NodeConfiguration &conf);
+  explicit Listen(
+    const std::string & xml_tag_name,
+    const std::string & action_name,
+    const BT::NodeConfiguration & conf);
 
   void on_tick() override;
   BT::NodeStatus on_success() override;
 
-  static BT::PortsList providedPorts() {
+  static BT::PortsList providedPorts()
+  {
     return BT::PortsList({BT::OutputPort<std::string>("listen_text")});
   }
 

--- a/bt_nodes/hri/include/hri/dialog/Listen.hpp
+++ b/bt_nodes/hri/include/hri/dialog/Listen.hpp
@@ -16,34 +16,33 @@
 #define HRI__LISTEN_HPP_
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 #include "behaviortree_cpp_v3/bt_factory.h"
 #include "hri/dialog/BTActionNode.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/int8.hpp"
 #include "whisper_msgs/action/stt.hpp"
 
-namespace dialog
-{
+namespace dialog {
 
-class Listen : public dialog::BtActionNode<whisper_msgs::action::STT>
-{
+class Listen : public dialog::BtActionNode<whisper_msgs::action::STT> {
 public:
-  explicit Listen(
-    const std::string & xml_tag_name,
-    const std::string & action_name,
-    const BT::NodeConfiguration & conf);
+  explicit Listen(const std::string &xml_tag_name,
+                  const std::string &action_name,
+                  const BT::NodeConfiguration &conf);
 
   void on_tick() override;
   BT::NodeStatus on_success() override;
 
-  static BT::PortsList providedPorts()
-  {
+  static BT::PortsList providedPorts() {
     return BT::PortsList({BT::OutputPort<std::string>("listen_text")});
   }
 
 private:
+  rclcpp::Publisher<std_msgs::msg::Int8>::SharedPtr publisher_start_;
 };
 
 } // namespace dialog

--- a/bt_nodes/hri/include/hri/dialog/Query.hpp
+++ b/bt_nodes/hri/include/hri/dialog/Query.hpp
@@ -23,32 +23,29 @@
 #include "hri/dialog/BTActionNode.hpp"
 #include "llama_msgs/action/generate_response.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/int8.hpp"
 
-namespace dialog
-{
+namespace dialog {
 
 class Query
-  : public dialog::BtActionNode<llama_msgs::action::GenerateResponse>
-{
+    : public dialog::BtActionNode<llama_msgs::action::GenerateResponse> {
 public:
-  explicit Query(
-    const std::string & xml_tag_name,
-    const std::string & action_name,
-    const BT::NodeConfiguration & conf);
+  explicit Query(const std::string &xml_tag_name,
+                 const std::string &action_name,
+                 const BT::NodeConfiguration &conf);
 
   void on_tick() override;
   BT::NodeStatus on_success() override;
 
-  static BT::PortsList providedPorts()
-  {
-    return BT::PortsList(
-      {BT::InputPort<std::string>("text"),
-        BT::InputPort<std::string>("intention"),
-        BT::OutputPort<std::string>("intention_value")});
+  static BT::PortsList providedPorts() {
+    return BT::PortsList({BT::InputPort<std::string>("text"),
+                          BT::InputPort<std::string>("intention"),
+                          BT::OutputPort<std::string>("intention_value")});
   }
 
 private:
   std::string intention_;
+  rclcpp::Publisher<std_msgs::msg::Int8>::SharedPtr publisher_start_;
 };
 
 } // namespace dialog

--- a/bt_nodes/hri/include/hri/dialog/Query.hpp
+++ b/bt_nodes/hri/include/hri/dialog/Query.hpp
@@ -25,22 +25,27 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/int8.hpp"
 
-namespace dialog {
+namespace dialog
+{
 
 class Query
-    : public dialog::BtActionNode<llama_msgs::action::GenerateResponse> {
+  : public dialog::BtActionNode<llama_msgs::action::GenerateResponse>
+{
 public:
-  explicit Query(const std::string &xml_tag_name,
-                 const std::string &action_name,
-                 const BT::NodeConfiguration &conf);
+  explicit Query(
+    const std::string & xml_tag_name,
+    const std::string & action_name,
+    const BT::NodeConfiguration & conf);
 
   void on_tick() override;
   BT::NodeStatus on_success() override;
 
-  static BT::PortsList providedPorts() {
-    return BT::PortsList({BT::InputPort<std::string>("text"),
-                          BT::InputPort<std::string>("intention"),
-                          BT::OutputPort<std::string>("intention_value")});
+  static BT::PortsList providedPorts()
+  {
+    return BT::PortsList(
+      {BT::InputPort<std::string>("text"),
+        BT::InputPort<std::string>("intention"),
+        BT::OutputPort<std::string>("intention_value")});
   }
 
 private:

--- a/bt_nodes/hri/include/hri/dialog/Speak.hpp
+++ b/bt_nodes/hri/include/hri/dialog/Speak.hpp
@@ -16,38 +16,36 @@
 #define DIALOG__SPEAK_HPP_
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 
 #include "audio_common_msgs/action/tts.hpp"
 #include "behaviortree_cpp_v3/behavior_tree.h"
 #include "behaviortree_cpp_v3/bt_factory.h"
 #include "hri/dialog/BTActionNode.hpp"
-#include "std_msgs/msg/string.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/int8.hpp"
+#include "std_msgs/msg/string.hpp"
 
-namespace dialog
-{
+namespace dialog {
 
-class Speak : public dialog::BtActionNode<audio_common_msgs::action::TTS>
-{
+class Speak : public dialog::BtActionNode<audio_common_msgs::action::TTS> {
 public:
-  explicit Speak(
-    const std::string & xml_tag_name,
-    const std::string & action_name,
-    const BT::NodeConfiguration & conf);
+  explicit Speak(const std::string &xml_tag_name,
+                 const std::string &action_name,
+                 const BT::NodeConfiguration &conf);
 
   void on_tick() override;
   BT::NodeStatus on_success() override;
 
-  static BT::PortsList providedPorts()
-  {
-    return BT::PortsList(
-      {BT::InputPort<std::string>("say_text"),
-        BT::InputPort<std::string>("param")});
+  static BT::PortsList providedPorts() {
+    return BT::PortsList({BT::InputPort<std::string>("say_text"),
+                          BT::InputPort<std::string>("param")});
   }
 
 private:
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+  rclcpp::Publisher<std_msgs::msg::Int8>::SharedPtr publisher_start_;
   // rclcpp::Node::SharedPtr node_;
   //  rclcpp::ActionClient<audio_common_msgs::action::TTS>::SharedPtr
   //  tts_action_;

--- a/bt_nodes/hri/include/hri/dialog/Speak.hpp
+++ b/bt_nodes/hri/include/hri/dialog/Speak.hpp
@@ -27,20 +27,25 @@
 #include "std_msgs/msg/int8.hpp"
 #include "std_msgs/msg/string.hpp"
 
-namespace dialog {
+namespace dialog
+{
 
-class Speak : public dialog::BtActionNode<audio_common_msgs::action::TTS> {
+class Speak : public dialog::BtActionNode<audio_common_msgs::action::TTS>
+{
 public:
-  explicit Speak(const std::string &xml_tag_name,
-                 const std::string &action_name,
-                 const BT::NodeConfiguration &conf);
+  explicit Speak(
+    const std::string & xml_tag_name,
+    const std::string & action_name,
+    const BT::NodeConfiguration & conf);
 
   void on_tick() override;
   BT::NodeStatus on_success() override;
 
-  static BT::PortsList providedPorts() {
-    return BT::PortsList({BT::InputPort<std::string>("say_text"),
-                          BT::InputPort<std::string>("param")});
+  static BT::PortsList providedPorts()
+  {
+    return BT::PortsList(
+      {BT::InputPort<std::string>("say_text"),
+        BT::InputPort<std::string>("param")});
   }
 
 private:

--- a/bt_nodes/hri/src/hri/dialog/DialogConfirmation.cpp
+++ b/bt_nodes/hri/src/hri/dialog/DialogConfirmation.cpp
@@ -21,21 +21,25 @@
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 
-namespace dialog {
+namespace dialog
+{
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;
 
-DialogConfirmation::DialogConfirmation(const std::string &xml_tag_name,
-                                       const std::string &action_name,
-                                       const BT::NodeConfiguration &conf)
-    : dialog::BtActionNode<whisper_msgs::action::STT>(xml_tag_name, action_name,
-                                                      conf) {
+DialogConfirmation::DialogConfirmation(
+  const std::string & xml_tag_name,
+  const std::string & action_name,
+  const BT::NodeConfiguration & conf)
+: dialog::BtActionNode<whisper_msgs::action::STT>(xml_tag_name, action_name,
+    conf)
+{
   this->publisher_start_ =
-      node_->create_publisher<std_msgs::msg::Int8>("dialog_action", 10);
+    node_->create_publisher<std_msgs::msg::Int8>("dialog_action", 10);
 }
 
-void DialogConfirmation::on_tick() {
+void DialogConfirmation::on_tick()
+{
 
   RCLCPP_DEBUG(node_->get_logger(), "DialogConfirmation ticked");
   std::string text_;
@@ -50,16 +54,18 @@ void DialogConfirmation::on_tick() {
   // goal_.text = text_;
 }
 
-BT::NodeStatus DialogConfirmation::on_success() {
+BT::NodeStatus DialogConfirmation::on_success()
+{
   fprintf(stderr, "%s\n", result_.result->text.c_str());
 
   if (result_.result->text.size() == 0) {
     return BT::NodeStatus::FAILURE;
   }
 
-  std::transform(result_.result->text.begin(), result_.result->text.end(),
-                 result_.result->text.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
+  std::transform(
+    result_.result->text.begin(), result_.result->text.end(),
+    result_.result->text.begin(),
+    [](unsigned char c) {return std::tolower(c);});
   if (result_.result->text.find("yes") != std::string::npos) {
     return BT::NodeStatus::SUCCESS;
   } else {
@@ -70,12 +76,14 @@ BT::NodeStatus DialogConfirmation::on_success() {
 } // namespace dialog
 #include "behaviortree_cpp_v3/bt_factory.h"
 BT_REGISTER_NODES(factory) {
-  BT::NodeBuilder builder = [](const std::string &name,
-                               const BT::NodeConfiguration &config) {
-    return std::make_unique<dialog::DialogConfirmation>(name, "/whisper/listen",
-                                                        config);
-  };
+  BT::NodeBuilder builder = [](const std::string & name,
+      const BT::NodeConfiguration & config) {
+      return std::make_unique<dialog::DialogConfirmation>(
+        name, "/whisper/listen",
+        config);
+    };
 
-  factory.registerBuilder<dialog::DialogConfirmation>("DialogConfirmation",
-                                                      builder);
+  factory.registerBuilder<dialog::DialogConfirmation>(
+    "DialogConfirmation",
+    builder);
 }

--- a/bt_nodes/hri/src/hri/dialog/DialogConfirmation.cpp
+++ b/bt_nodes/hri/src/hri/dialog/DialogConfirmation.cpp
@@ -16,46 +16,50 @@
 #include <utility>
 
 #include "hri/dialog/DialogConfirmation.hpp"
+#include "std_msgs/msg/int8.hpp"
 #include "whisper_msgs/action/stt.hpp"
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 
-namespace dialog
-{
+namespace dialog {
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;
 
-DialogConfirmation::DialogConfirmation(
-  const std::string & xml_tag_name,
-  const std::string & action_name,
-  const BT::NodeConfiguration & conf)
-: dialog::BtActionNode<whisper_msgs::action::STT>(xml_tag_name, action_name,
-    conf) {}
+DialogConfirmation::DialogConfirmation(const std::string &xml_tag_name,
+                                       const std::string &action_name,
+                                       const BT::NodeConfiguration &conf)
+    : dialog::BtActionNode<whisper_msgs::action::STT>(xml_tag_name, action_name,
+                                                      conf) {
+  this->publisher_start_ =
+      node_->create_publisher<std_msgs::msg::Int8>("dialog_action", 10);
+}
 
-void DialogConfirmation::on_tick()
-{
+void DialogConfirmation::on_tick() {
 
   RCLCPP_DEBUG(node_->get_logger(), "DialogConfirmation ticked");
   std::string text_;
   // getInput("prompt", text_);
   goal_ = whisper_msgs::action::STT::Goal();
+  auto msg_dialog_action = std_msgs::msg::Int8();
+
+  msg_dialog_action.data = 0;
+
+  this->publisher_start_->publish(msg_dialog_action);
 
   // goal_.text = text_;
 }
 
-BT::NodeStatus DialogConfirmation::on_success()
-{
+BT::NodeStatus DialogConfirmation::on_success() {
   fprintf(stderr, "%s\n", result_.result->text.c_str());
 
   if (result_.result->text.size() == 0) {
     return BT::NodeStatus::FAILURE;
   }
 
-  std::transform(
-    result_.result->text.begin(), result_.result->text.end(),
-    result_.result->text.begin(),
-    [](unsigned char c) {return std::tolower(c);});
+  std::transform(result_.result->text.begin(), result_.result->text.end(),
+                 result_.result->text.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
   if (result_.result->text.find("yes") != std::string::npos) {
     return BT::NodeStatus::SUCCESS;
   } else {
@@ -66,14 +70,12 @@ BT::NodeStatus DialogConfirmation::on_success()
 } // namespace dialog
 #include "behaviortree_cpp_v3/bt_factory.h"
 BT_REGISTER_NODES(factory) {
-  BT::NodeBuilder builder = [](const std::string & name,
-      const BT::NodeConfiguration & config) {
-      return std::make_unique<dialog::DialogConfirmation>(
-        name, "/whisper/listen",
-        config);
-    };
+  BT::NodeBuilder builder = [](const std::string &name,
+                               const BT::NodeConfiguration &config) {
+    return std::make_unique<dialog::DialogConfirmation>(name, "/whisper/listen",
+                                                        config);
+  };
 
-  factory.registerBuilder<dialog::DialogConfirmation>(
-    "DialogConfirmation",
-    builder);
+  factory.registerBuilder<dialog::DialogConfirmation>("DialogConfirmation",
+                                                      builder);
 }

--- a/bt_nodes/hri/src/hri/dialog/Listen.cpp
+++ b/bt_nodes/hri/src/hri/dialog/Listen.cpp
@@ -22,20 +22,24 @@
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 
-namespace dialog {
+namespace dialog
+{
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;
 
-Listen::Listen(const std::string &xml_tag_name, const std::string &action_name,
-               const BT::NodeConfiguration &conf)
-    : dialog::BtActionNode<whisper_msgs::action::STT>(xml_tag_name, action_name,
-                                                      conf) {
+Listen::Listen(
+  const std::string & xml_tag_name, const std::string & action_name,
+  const BT::NodeConfiguration & conf)
+: dialog::BtActionNode<whisper_msgs::action::STT>(xml_tag_name, action_name,
+    conf)
+{
   this->publisher_start_ =
-      node_->create_publisher<std_msgs::msg::Int8>("dialog_action", 10);
+    node_->create_publisher<std_msgs::msg::Int8>("dialog_action", 10);
 }
 
-void Listen::on_tick() {
+void Listen::on_tick()
+{
 
   RCLCPP_DEBUG(node_->get_logger(), "Listen ticked");
   std::string text_;
@@ -47,7 +51,8 @@ void Listen::on_tick() {
   this->publisher_start_->publish(msg_dialog_action);
 }
 
-BT::NodeStatus Listen::on_success() {
+BT::NodeStatus Listen::on_success()
+{
   fprintf(stderr, "%s\n", result_.result->text.c_str());
 
   if (result_.result->text.size() == 0) {
@@ -61,10 +66,10 @@ BT::NodeStatus Listen::on_success() {
 } // namespace dialog
 #include "behaviortree_cpp_v3/bt_factory.h"
 BT_REGISTER_NODES(factory) {
-  BT::NodeBuilder builder = [](const std::string &name,
-                               const BT::NodeConfiguration &config) {
-    return std::make_unique<dialog::Listen>(name, "whisper/listen", config);
-  };
+  BT::NodeBuilder builder = [](const std::string & name,
+      const BT::NodeConfiguration & config) {
+      return std::make_unique<dialog::Listen>(name, "whisper/listen", config);
+    };
 
   factory.registerBuilder<dialog::Listen>("Listen", builder);
 }

--- a/bt_nodes/hri/src/hri/dialog/Query.cpp
+++ b/bt_nodes/hri/src/hri/dialog/Query.cpp
@@ -23,36 +23,40 @@
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 
-namespace dialog {
+namespace dialog
+{
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;
 using json = nlohmann::json;
 
-Query::Query(const std::string &xml_tag_name, const std::string &action_name,
-             const BT::NodeConfiguration &conf)
-    : dialog::BtActionNode<llama_msgs::action::GenerateResponse>(
-          xml_tag_name, action_name, conf) {
+Query::Query(
+  const std::string & xml_tag_name, const std::string & action_name,
+  const BT::NodeConfiguration & conf)
+: dialog::BtActionNode<llama_msgs::action::GenerateResponse>(
+    xml_tag_name, action_name, conf)
+{
   this->publisher_start_ =
-      node_->create_publisher<std_msgs::msg::Int8>("dialog_action", 10);
+    node_->create_publisher<std_msgs::msg::Int8>("dialog_action", 10);
 }
 
-void Query::on_tick() {
+void Query::on_tick()
+{
 
   RCLCPP_DEBUG(node_->get_logger(), "Query ticked");
   std::string text_;
   getInput("text", text_);
   getInput("intention", intention_);
   std::string prompt_ =
-      "Given the sentence \"" + text_ + "\", extract the " + intention_ +
-      " from the sentence and return "
-      "it with the following JSON format:\n" +
-      "{\n\t\"intention\": \"word extracted in the sentence\"\n}";
+    "Given the sentence \"" + text_ + "\", extract the " + intention_ +
+    " from the sentence and return "
+    "it with the following JSON format:\n" +
+    "{\n\t\"intention\": \"word extracted in the sentence\"\n}";
   goal_.prompt = prompt_;
   goal_.reset = true;
   goal_.sampling_config.temp = 0.0;
   goal_.sampling_config.grammar =
-      R"(root   ::= object
+    R"(root   ::= object
 value  ::= object | array | string | number | ("true" | "false" | "null") ws
 
 object ::=
@@ -85,11 +89,13 @@ ws ::= ([ \t\n] ws)?)";
   this->publisher_start_->publish(msg_dialog_action);
 }
 
-BT::NodeStatus Query::on_success() {
+BT::NodeStatus Query::on_success()
+{
   fprintf(stderr, "%s\n", result_.result->response.text.c_str());
 
   if (result_.result->response.text.empty() ||
-      result_.result->response.text == "{}") {
+    result_.result->response.text == "{}")
+  {
     return BT::NodeStatus::FAILURE;
   }
 
@@ -110,11 +116,12 @@ BT::NodeStatus Query::on_success() {
 } // namespace dialog
 #include "behaviortree_cpp_v3/bt_factory.h"
 BT_REGISTER_NODES(factory) {
-  BT::NodeBuilder builder = [](const std::string &name,
-                               const BT::NodeConfiguration &config) {
-    return std::make_unique<dialog::Query>(name, "/llama/generate_response",
-                                           config);
-  };
+  BT::NodeBuilder builder = [](const std::string & name,
+      const BT::NodeConfiguration & config) {
+      return std::make_unique<dialog::Query>(
+        name, "/llama/generate_response",
+        config);
+    };
 
   factory.registerBuilder<dialog::Query>("Query", builder);
 }

--- a/bt_nodes/hri/src/hri/dialog/Speak.cpp
+++ b/bt_nodes/hri/src/hri/dialog/Speak.cpp
@@ -23,22 +23,26 @@
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 
-namespace dialog {
+namespace dialog
+{
 using namespace std::chrono_literals;
 using namespace std::placeholders;
 
-Speak::Speak(const std::string &xml_tag_name, const std::string &action_name,
-             const BT::NodeConfiguration &conf)
-    : dialog::BtActionNode<audio_common_msgs::action::TTS>(xml_tag_name,
-                                                           action_name, conf) {
+Speak::Speak(
+  const std::string & xml_tag_name, const std::string & action_name,
+  const BT::NodeConfiguration & conf)
+: dialog::BtActionNode<audio_common_msgs::action::TTS>(xml_tag_name,
+    action_name, conf)
+{
   node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
   this->publisher_ =
-      node_->create_publisher<std_msgs::msg::String>("say_text", 10);
+    node_->create_publisher<std_msgs::msg::String>("say_text", 10);
   this->publisher_start_ =
-      node_->create_publisher<std_msgs::msg::Int8>("dialog_action", 10);
+    node_->create_publisher<std_msgs::msg::Int8>("dialog_action", 10);
 }
 
-void Speak::on_tick() {
+void Speak::on_tick()
+{
   RCLCPP_DEBUG(node_->get_logger(), "Speak ticked");
   std::string text_;
 
@@ -63,14 +67,14 @@ void Speak::on_tick() {
   this->publisher_start_->publish(msg_dialog_action);
 }
 
-BT::NodeStatus Speak::on_success() { return BT::NodeStatus::SUCCESS; }
+BT::NodeStatus Speak::on_success() {return BT::NodeStatus::SUCCESS;}
 } // namespace dialog
 #include "behaviortree_cpp_v3/bt_factory.h"
 BT_REGISTER_NODES(factory) {
-  BT::NodeBuilder builder = [](const std::string &name,
-                               const BT::NodeConfiguration &config) {
-    return std::make_unique<dialog::Speak>(name, "/say", config);
-  };
+  BT::NodeBuilder builder = [](const std::string & name,
+      const BT::NodeConfiguration & config) {
+      return std::make_unique<dialog::Speak>(name, "/say", config);
+    };
 
   factory.registerBuilder<dialog::Speak>("Speak", builder);
 }

--- a/bt_nodes/hri/src/hri/dialog/Speak.cpp
+++ b/bt_nodes/hri/src/hri/dialog/Speak.cpp
@@ -12,33 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <string>
 #include <utility>
 
 #include "audio_common_msgs/action/tts.hpp"
 #include "hri/dialog/Speak.hpp"
+#include "std_msgs/msg/int8.hpp"
 #include "std_msgs/msg/string.hpp"
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 
-namespace dialog
-{
+namespace dialog {
 using namespace std::chrono_literals;
 using namespace std::placeholders;
 
-Speak::Speak(
-  const std::string & xml_tag_name,
-  const std::string & action_name,
-  const BT::NodeConfiguration & conf)
-: dialog::BtActionNode<audio_common_msgs::action::TTS>(xml_tag_name, action_name, conf)
-{
+Speak::Speak(const std::string &xml_tag_name, const std::string &action_name,
+             const BT::NodeConfiguration &conf)
+    : dialog::BtActionNode<audio_common_msgs::action::TTS>(xml_tag_name,
+                                                           action_name, conf) {
   node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
-  this->publisher_ = node_->create_publisher<std_msgs::msg::String>("say_text", 10);
+  this->publisher_ =
+      node_->create_publisher<std_msgs::msg::String>("say_text", 10);
+  this->publisher_start_ =
+      node_->create_publisher<std_msgs::msg::Int8>("dialog_action", 10);
 }
 
-void
-Speak::on_tick()
-{
+void Speak::on_tick() {
   RCLCPP_DEBUG(node_->get_logger(), "Speak ticked");
   std::string text_;
 
@@ -54,20 +54,23 @@ Speak::on_tick()
   }
 
   auto msg = std_msgs::msg::String();
+  auto msg_dialog_action = std_msgs::msg::Int8();
 
   msg.data = goal_.text;
+  msg_dialog_action.data = 1;
+
   this->publisher_->publish(msg);
+  this->publisher_start_->publish(msg_dialog_action);
 }
 
-BT::NodeStatus Speak::on_success() {return BT::NodeStatus::SUCCESS;}
+BT::NodeStatus Speak::on_success() { return BT::NodeStatus::SUCCESS; }
 } // namespace dialog
 #include "behaviortree_cpp_v3/bt_factory.h"
-BT_REGISTER_NODES(factory)
-{
-  BT::NodeBuilder builder = [](const std::string & name,
-      const BT::NodeConfiguration & config) {
-      return std::make_unique<dialog::Speak>(name, "/say", config);
-    };
+BT_REGISTER_NODES(factory) {
+  BT::NodeBuilder builder = [](const std::string &name,
+                               const BT::NodeConfiguration &config) {
+    return std::make_unique<dialog::Speak>(name, "/say", config);
+  };
 
   factory.registerBuilder<dialog::Speak>("Speak", builder);
 }

--- a/bt_nodes/hri/src/hri/dialog/Speak.cpp
+++ b/bt_nodes/hri/src/hri/dialog/Speak.cpp
@@ -27,47 +27,47 @@ using namespace std::chrono_literals;
 using namespace std::placeholders;
 
 Speak::Speak(
-    const std::string           & xml_tag_name,
-    const std::string           & action_name,
-    const BT::NodeConfiguration & conf)
-    : dialog::BtActionNode<audio_common_msgs::action::TTS>(xml_tag_name, action_name, conf)
+  const std::string & xml_tag_name,
+  const std::string & action_name,
+  const BT::NodeConfiguration & conf)
+: dialog::BtActionNode<audio_common_msgs::action::TTS>(xml_tag_name, action_name, conf)
 {
-    node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
-    this->publisher_ = node_->create_publisher<std_msgs::msg::String>("say_text", 10);
+  node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+  this->publisher_ = node_->create_publisher<std_msgs::msg::String>("say_text", 10);
 }
 
 void
 Speak::on_tick()
 {
-    RCLCPP_DEBUG(node_->get_logger(), "Speak ticked");
-    std::string text_;
+  RCLCPP_DEBUG(node_->get_logger(), "Speak ticked");
+  std::string text_;
 
-    getInput("say_text", text_);
-    std::string param_;
+  getInput("say_text", text_);
+  std::string param_;
 
-    getInput("param", param_);
+  getInput("param", param_);
 
-    if (param_.length() > 0) {
-        goal_.text = text_ + " " + param_ + "?";
-    } else {
-        goal_.text = text_;
-    }
+  if (param_.length() > 0) {
+    goal_.text = text_ + " " + param_ + "?";
+  } else {
+    goal_.text = text_;
+  }
 
-    auto msg = std_msgs::msg::String();
+  auto msg = std_msgs::msg::String();
 
-    msg.data = goal_.text;
-    this->publisher_->publish(msg);
+  msg.data = goal_.text;
+  this->publisher_->publish(msg);
 }
 
-BT::NodeStatus Speak::on_success(){ return BT::NodeStatus::SUCCESS; }
+BT::NodeStatus Speak::on_success() {return BT::NodeStatus::SUCCESS;}
 } // namespace dialog
 #include "behaviortree_cpp_v3/bt_factory.h"
 BT_REGISTER_NODES(factory)
 {
-    BT::NodeBuilder builder = [](const std::string & name,
-        const BT::NodeConfiguration & config){
-          return std::make_unique<dialog::Speak>(name, "/say", config);
-      };
+  BT::NodeBuilder builder = [](const std::string & name,
+      const BT::NodeConfiguration & config) {
+      return std::make_unique<dialog::Speak>(name, "/say", config);
+    };
 
-    factory.registerBuilder<dialog::Speak>("Speak", builder);
+  factory.registerBuilder<dialog::Speak>("Speak", builder);
 }


### PR DESCRIPTION
This pull request adds a new topic **/dialog_action**. The purpose of this topic is to provide information about the current state of a dialog action.

Details of the Topic (/dialog_action):

- Listen: When the state is 0, it indicates that the dialog action is in the listening process.
- Speak: When the state is 1, it indicates that the dialog action is in the speaking process.
- Think (Query): When the state is 2, it indicates that the dialog action is in the thinking process or performing a query.